### PR TITLE
fix: strip parameter from unnecessary space at the end

### DIFF
--- a/addons/cheatsheet/scripts/command_db.gd
+++ b/addons/cheatsheet/scripts/command_db.gd
@@ -121,13 +121,13 @@ func get_args(str: String) -> PackedStringArray:
 				is_str = true
 				continue
 		
-		# normal argument
-		word.append(ch)
-		
 		if ch == ' ':
 			is_start = true
 			submit.call()
 			continue
+
+		# normal argument
+		word.append(ch)
 	
 	submit.call()
 	


### PR DESCRIPTION
In get_args continue before appending space to the final word.